### PR TITLE
Added destroy method

### DIFF
--- a/media/js/ColReorder.js
+++ b/media/js/ColReorder.js
@@ -404,11 +404,8 @@ ColReorder = function( oDTSettings, oOpts )
 	this._fnConstruct();
 
 	/* Add destroy callback */
-	oDTSettings.aoDestroyCallback.push({
-		"fn" : jQuery.proxy(this._fnDestroy, this),
-		"sName" : "ColReorder"
-	});
-	
+	oDTSettings.oApi._fnCallbackReg(oDTSettings, 'aoDestroyCallback', jQuery.proxy(this._fnDestroy, this), 'ColReorder');
+
 	/* Store the instance for later use */
 	ColReorder.aoInstances.push( this );
 	return this;


### PR DESCRIPTION
I added a destroy method to clean up memory references and event handlers and prevent the plugin from hanging around in memory after the data table is destroyed.
