### PR TITLE
Replacing 'jQuery' variable name with '$' sign

### DIFF
--- a/media/js/ColReorder.js
+++ b/media/js/ColReorder.js
@@ -412,7 +412,7 @@ ColReorder = function( oDTSettings, oOpts )
 	this._fnConstruct();
 
 	/* Add destroy callback */
-	oDTSettings.oApi._fnCallbackReg(oDTSettings, 'aoDestroyCallback', jQuery.proxy(this._fnDestroy, this), 'ColReorder');
+	oDTSettings.oApi._fnCallbackReg(oDTSettings, 'aoDestroyCallback', $.proxy(this._fnDestroy, this), 'ColReorder');
 
 	/* Store the instance for later use */
 	ColReorder.aoInstances.push( this );


### PR DESCRIPTION
Currently in the ColReorder plugin, there were calls to jQuery.proxy()
using the jQuery global namespace. While this
might not be an issue while loading the libraries externally, but if
your project has a RequireJS AMD setup then you would led to an error
saying jQuery is not defined. In order to fix this, we could use a $
sign instead of the jQuery namespace while calling the $.proxy API. This
commit would address this issue.
