### PR TITLE
Fix destroy and initialize problem

### DIFF
--- a/media/js/ColReorder.js
+++ b/media/js/ColReorder.js
@@ -1268,7 +1268,7 @@ if ( typeof $.fn.dataTable == "function" &&
 		"fnInit": function( settings ) {
 			var table = settings.oInstance;
 
-			if ( table._oPluginColReorder === undefined ) {
+			if ( table._oPluginColReorder === undefined || table._oPluginColReorder === null ) {
 				var opts = settings.oInit.oColReorder !== undefined ?
 					settings.oInit.oColReorder :
 					{};


### PR DESCRIPTION
When destroying, the `_oPluginColReorder` prop is set to `null` but the check on init is only for `undefined`, which causes ColReorder to think that it's already initialized.

Comparing to `null` with type coercion will check for both `null` and `undefined`.
