### PR TITLE
Fixed JQuery reference when using RequireJS's dependency system

### DIFF
--- a/js/dataTables.colReorder.js
+++ b/js/dataTables.colReorder.js
@@ -90,6 +90,11 @@ function fnDomSwitch( nParent, iFrom, iTo )
 
 
 
+
+var factory = function( $, DataTable ) {
+"use strict";
+
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * DataTables plug-in API functions
  *
@@ -308,9 +313,6 @@ $.fn.dataTableExt.oApi.fnColReorder = function ( oSettings, iFrom, iTo )
 };
 
 
-
-var factory = function( $, DataTable ) {
-"use strict";
 
 /**
  * ColReorder provides column visibility control for DataTables


### PR DESCRIPTION
At line #110 there is a '$' referring to the JQuery instance, but it is defined only for the 'factory' function.
```js
/**
 * Plug-in for DataTables which will reorder the internal column structure by taking the column
 * from one position (iFrom) and insert it into a given point (iTo).
 *  @method  $.fn.dataTableExt.oApi.fnColReorder
 *  @param   object oSettings DataTables settings object - automatically added by DataTables!
 *  @param   int iFrom Take the column to be repositioned from this point
 *  @param   int iTo and insert it into this point
 *  @returns void
 */
$.fn.dataTableExt.oApi.fnColReorder = function ( oSettings, iFrom, iTo )
{
	....
```
Regards,
Giacomo