### PR TITLE
The thead and tr tags were not being inserted properly into the dom

### DIFF
--- a/js/dataTables.colReorder.js
+++ b/js/dataTables.colReorder.js
@@ -1042,23 +1042,23 @@ ColReorder.prototype = {
 		// This is a slightly odd combination of jQuery and DOM, but it is the
 		// fastest and least resource intensive way I could think of cloning
 		// the table with just a single header cell in it.
-		this.dom.drag = $(origTable.cloneNode(false))
-			.addClass( 'DTCR_clonedTable' )
-			.append(
-				origThead.cloneNode(false).appendChild(
-					origTr.cloneNode(false).appendChild(
-						cloneCell[0]
-					)
-				)
-			)
-			.css( {
-				position: 'absolute',
-				top: 0,
-				left: 0,
-				width: $(origCell).outerWidth(),
-				height: $(origCell).outerHeight()
-			} )
-			.appendTo( 'body' );
+        this.dom.drag = $(origTable.cloneNode(false))
+            .addClass( 'DTCR_clonedTable' )
+            .append(
+            origThead.cloneNode(false)
+                .appendChild(origTr.cloneNode(false))
+                .appendChild(cloneCell.css({height: $(origCell).height()})[0])
+                .parentNode.parentNode
+        )
+            .css( {
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                minWidth: 0,
+                width: $(origCell).outerWidth(),
+                height: $(origCell).outerHeight()
+            } )
+            .appendTo( 'body' );
 
 		this.dom.pointer = $('<div></div>')
 			.addClass( 'DTCR_pointer' )


### PR DESCRIPTION
I was using bootstrap with datatables.  The thead tr missing were causing me headaches with css.  I played with the height some to get it to work with my page. My header columns were a few lines high.  

I also set the minWidth to 0.  The scenario I ran into was I had a table that flowed outside the screen. Datatables elegantly put a minWidth on my table to do this.  But caused a problem when I clicked to drag a column, the dragable column would be the whole table width since it cloned the tables minwidth. 
