### PR TITLE
fnDomSwitch skips undefined indexes instead of throwing a TypeError, allowing simple colspan configurations to work as expected.

### DIFF
--- a/js/dataTables.colReorder.js
+++ b/js/dataTables.colReorder.js
@@ -76,6 +76,10 @@ function fnDomSwitch( nParent, iFrom, iTo )
 			anTags.push( nParent.childNodes[i] );
 		}
 	}
+
+    if(typeof anTags[ iFrom ] === 'undefined'){
+        return;
+    }
 	var nStore = anTags[ iFrom ];
 
 	if ( iTo !== null )


### PR DESCRIPTION
Added check for unidentified index anTags[ iFrom ] to fnDomSwitch to allow trs with no value in the moved column to be skipped when moving. This allows simple colspan configurations to work, although it may cause unintended results in complex table configurations.
