### PR TITLE
Fixing zIndex

### DIFF
--- a/js/dataTables.colReorder.js
+++ b/js/dataTables.colReorder.js
@@ -1050,7 +1050,8 @@ $.extend( ColReorder.prototype, {
 				top: 0,
 				left: 0,
 				width: $(origCell).outerWidth(),
-				height: $(origCell).outerHeight()
+				height: $(origCell).outerHeight(),
+				zIndex: $(origCell).zIndex()
 			} )
 			.appendTo( 'body' );
 


### PR DESCRIPTION
Setting the zIndex for floating header to prevent it from rendering behind the table.