### PR TITLE
Fix: clear aoColumns[]._setter so it gets regenerated on next call to…

### DIFF
--- a/js/dataTables.colReorder.js
+++ b/js/dataTables.colReorder.js
@@ -218,9 +218,6 @@ $.fn.dataTableExt.oApi.fnColReorder = function ( oSettings, iFrom, iTo, drop )
 
 		if ( typeof oCol.mData == 'number' ) {
 			oCol.mData = aiInvertMapping[ oCol.mData ];
-
-			// regenerate the get / set functions
-			oSettings.oApi._fnColumnOptions( oSettings, i, {} );
 		}
 		else if ( $.isPlainObject( oCol.mData ) ) {
 			// HTML5 data sourced
@@ -229,9 +226,14 @@ $.fn.dataTableExt.oApi.fnColReorder = function ( oSettings, iFrom, iTo, drop )
 			attrMap( oCol.mData, 'sort',   aiInvertMapping );
 			attrMap( oCol.mData, 'type',   aiInvertMapping );
 
-			// regenerate the get / set functions
-			oSettings.oApi._fnColumnOptions( oSettings, i, {} );
 		}
+
+		// wipe cached '._setter()' used _fnGetRowElements() --
+		// bound to colIdx, but will be regenerated.
+		oCol._setter = null;
+
+		// regenerate the get / set functions
+		oSettings.oApi._fnColumnOptions( oSettings, i, {} );
 	}
 
 


### PR DESCRIPTION
I ran into an edge case where using colReorder would cause various "tech note 4" errors in datatables core.  My case was slightly different, but I think it's the same problem as issue #39, where reordering columns caused an error when trying to sort columns after reordering.

After tracking it down, I determined the problem was the following:  when colReorder finishes updating all the internals after a reorder, it calls .rows.invalidate() in datatable core, which calls _fnInvalidate(), which calls _fnGetRowElements().  Under a certain code path in _fnGetRowElements(), it stores a cached function in aoColumns[]._setter, which happens to hardcode the index of the column as part of it's bound parameters.   This attribute doesn't get cleared by colReorder, and subsequent calls to _fnGetRowElements() end up using the wrong column index, resulting in incomplete data within aoData[]._adata.  

This PR adds a call to colReorder to explicitly clear this cached function, so it will be rebuilt correctly next time.   Which fixes my use case, and well as seems to make the example from issue #39 work again.

---

However, it might be a better design choice to reject this PR, and instead have datatable core's _fnColumnOptions() clear the column data's ._setter attribute.  That function already resets all the other related attributes anyways, and colReorder is already invoking that function.  That also fixes both my use-case and the example from issue 39.