### PR TITLE
adding support for DT.responsive class logic

### DIFF
--- a/js/dataTables.colReorder.js
+++ b/js/dataTables.colReorder.js
@@ -1064,7 +1064,7 @@ $.extend( ColReorder.prototype, {
 				iToPoint++;
 			}
 
-			if ( aoColumns[i].bVisible && aoColumns[i].sClass.indexOf("never") === -1 )
+			if ( aoColumns[i].bVisible && aoColumns[i].nTh.style.display !=='none' )
 			{
 				total += $(aoColumns[i].nTh).outerWidth();
 

--- a/js/dataTables.colReorder.js
+++ b/js/dataTables.colReorder.js
@@ -1064,7 +1064,7 @@ $.extend( ColReorder.prototype, {
 				iToPoint++;
 			}
 
-			if ( aoColumns[i].bVisible )
+			if ( aoColumns[i].bVisible && aoColumns[i].sClass.indexOf("never") === -1 )
 			{
 				total += $(aoColumns[i].nTh).outerWidth();
 


### PR DESCRIPTION
DataTables Responsive can use a special class called "never" which indicates that a column should never be visible. When the class is used, the column is still placed in the table, but its style is `style="display: none; width: 0px;"`, but using the "never" class does not set Column.bVisible to false because the column is being output into the HTML. This causes a bug when using colReorder where when a column is being reordered and dragged to the right over a column with the class of "never" the calculated location for the column to be moved to is less than the actual distance dragged because while the width of the column is set to 0px, the column outerWidth includes any potential padding on the column.

This bug fix filters out the widths of the columns which have a class of "never" so their widths are never used when calculating the location where the column would be dropped.