### PR TITLE
Speed up col reorder call

### DIFF
--- a/js/dataTables.colReorder.js
+++ b/js/dataTables.colReorder.js
@@ -1071,7 +1071,7 @@ $.extend( ColReorder.prototype, {
 		} );
 
 		var iToPoint = 0;
-		var total = $(aoColumns[0].nTh).offset().left; // Offset of the first column
+		var total = this.s.aoTargets[0].x;
 
 		for ( var i=0, iLen=aoColumns.length ; i<iLen ; i++ )
 		{


### PR DESCRIPTION
Doing a table.colReorder.order( [stuff], true ); for arrays with large length locks up the browser really bad. I've narrowed it down to the lines

```javascript
var api = new $.fn.dataTable.Api( oSettings );
api.rows().invalidate();
```

I've moved these out and already the speed of doing this on my table of ~45 columns on my fairly new macbook pro went from ~8 seconds to around just over 1 second. I would imagine some other optimizations could be made if I took the time to understand the code more. Or at least issue in some timeouts to prevent the lock in. But it's a start?

