### PR TITLE
Remove preventDefault

### DIFF
--- a/js/dataTables.colReorder.js
+++ b/js/dataTables.colReorder.js
@@ -889,7 +889,6 @@ $.extend( ColReorder.prototype, {
 		var that = this;
 		$(nTh)
 			.on( 'mousedown.ColReorder', function (e) {
-				e.preventDefault();
 				that._fnMouseDown.call( that, e, nTh );
 			} )
 			.on( 'touchstart.ColReorder', function (e) {


### PR DESCRIPTION
When one populates the heading with inputs etc. and this extension is active; clicks inside the `th` are no longer possible. For example: focus on an input element.

After removing `preventDefault()` and testing it locally, I am unable to see the benefits of it as `sorting` is not activated when dragging a column.