### PR TITLE
Programmatically move a column

### DIFF
--- a/js/dataTables.colReorder.js
+++ b/js/dataTables.colReorder.js
@@ -1348,9 +1348,10 @@ $.fn.dataTable.Api.register( 'colReorder.transpose()', function ( idx, dir ) {
 } );
 
 $.fn.dataTable.Api.register( 'colReorder.move()', function( from, to, drop, invalidateRows ) {
-	return this.context.length ?
-		this.context[0]._colReorder.s.dt.oInstance.fnColReorder( from, to, drop, invalidateRows ) :
-		null;
+	if (this.context.length) {
+		this.context[0]._colReorder.s.dt.oInstance.fnColReorder( from, to, drop, invalidateRows );
+	}
+	return this;
 } );
 
 

--- a/js/dataTables.colReorder.js
+++ b/js/dataTables.colReorder.js
@@ -1348,7 +1348,9 @@ $.fn.dataTable.Api.register( 'colReorder.transpose()', function ( idx, dir ) {
 } );
 
 $.fn.dataTable.Api.register( 'colReorder.move()', function( from, to, drop, invalidateRows ) {
-	this.context[0]._colReorder.s.dt.oInstance.fnColReorder( from, to, drop, invalidateRows )
+	return this.context.length ?
+		this.context[0]._colReorder.s.dt.oInstance.fnColReorder( from, to, drop, invalidateRows ) :
+		null;
 } );
 
 

--- a/js/dataTables.colReorder.js
+++ b/js/dataTables.colReorder.js
@@ -1347,6 +1347,10 @@ $.fn.dataTable.Api.register( 'colReorder.transpose()', function ( idx, dir ) {
 		idx;
 } );
 
+$.fn.dataTable.Api.register( 'colReorder.move()', function( from, to, drop, invalidateRows ) {
+	this.context[0]._colReorder.s.dt.oInstance.fnColReorder( from, to, drop, invalidateRows )
+} );
+
 
 return ColReorder;
 }));


### PR DESCRIPTION
Added a `move()` function to provide direct api access to the `fnColReorder()` function.
That way you can move/reorder a column programmatically.

```js
var table = $("table").DataTable();
table.colReorder.move(fromIndex, toIndex, drop, invalidate);
```