### PR TITLE
Add columns-reordered-dropped event for final column reorder completion

### DIFF
--- a/js/ColReorder.ts
+++ b/js/ColReorder.ts
@@ -348,6 +348,13 @@ export default class ColReorder {
 		}
 
 		this.dt.cells('.dtcr-moving').nodes().to$().removeClass('dtcr-moving dtcr-moving-first dtcr-moving-last');
+
+		this.dt.trigger('columns-reordered-dropped', [
+		  {
+			  order: this.dt.colReorder.order(),
+			  mapping: invertKeyValues(order)
+		  }
+		]);
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces a columns-reordered-dropped event to trigger only once after the column is dropped into its final position. Unlike the existing events that fire during intermediate dragging, this event provides a cleaner, more efficient way to handle actions that depend on the final column order.