### PR TITLE
Resolve thrown ReferenceError when used with state restoration and nonfunctional UI during column dragging

### DIFF
--- a/js/ColReorder.ts
+++ b/js/ColReorder.ts
@@ -280,8 +280,8 @@ export default class ColReorder {
 
 		// Position the element - we respect where in the element the click occurred
 		this.dom.drag.css({
-			left: this._cursorPosition(e, 'pageX') - this.s.mouse.offset.x,
-			top: this._cursorPosition(e, 'pageY') - this.s.mouse.offset.y
+			left: `${this._cursorPosition(e, 'pageX') - this.s.mouse.offset.x}px`,
+			top: `${this._cursorPosition(e, 'pageY') - this.s.mouse.offset.y}px`
 		});
 
 		// Find cursor's left position relative to the table

--- a/js/functions.ts
+++ b/js/functions.ts
@@ -228,7 +228,7 @@ export function move(dt: Api, from: number[], to: number): void {
 	// the search applies to, which needs to be updated, but also there is a
 	// `columns` array for each property which must also be updated.
 	util.object.each(settings.searches, (key, search) => {
-		let columns = transposeArray(search.columns, reverseIndexes);
+		let columns = transposeArray(search.columns ?? [], reverseIndexes);
 
 		// In case there is an overlap between those which have been reordered
 		// and those still to be done, we need to use a name that indicates that


### PR DESCRIPTION
This PR addresses two issues, which appear to have been the result of updating the extension for DataTables 3.0:

- When using automatic state save and restore via `stateStave`, `stateSaveCallback`, and `stateLoadCallback`, in a table in which search is enabled but not in use, the state which is saved and later loaded can end up having `settings.searches["*"].column === null`. This causes a `ReferenceError` to be thrown in `transposeArray()` due to attempting to access `null.length`. Because I am not familiar enough with how searching works internally in DataTables 3.0 to figure out whether or not the `null` value is expected or the result of a separate state handling issue, I resolved the issue by adding a fallback to an empty via optional chaining when `search.columns` is `null` or `undefined`.

- When dragging a column to reorder it, the `mousemove` handler repositions the drag node by settings its `left` and `top` CSS properties via `Dom.css()`. However, the handler specifies both coordinates as plain numbers with no units. The browser therefore ignores the change altogether, leaving the UI element pinned to the top-left of the viewport. While it is my experience that using `transform: translate(var(--x-coord), var(--y-coord)); will-change: transform;` (the custom property names are just an example of course) and setting `--x-coord` and `--y-coord` on the element is significantly more performant in modern browsers than adjusting the absolute position of an element when implementing drag semantics (IIUC, this is due to a combination of GPU-accelerated transforms and reduced need for layout recalculation), such a change would be out of scope for a simple bug fix, and I cannot say whether or not there's a reason that using a transform would not be appropriate for this code. Therefore, I resolved the issue by just adding the missing `px` suffixes to the property values in the call to `Dom.css()`.